### PR TITLE
feat: use Display Metrics on dragFloatingWindow

### DIFF
--- a/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -184,8 +184,21 @@ class ComposeFloatingWindow(
         private set
 
     private val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    val display = DisplayHelper(context, windowManager)
     private var composeView: ComposeView? = null // Hold a direct reference
     private var parentComposition: Recomposer? = null // Hold reference for disposal
+
+    /**
+     * The maximum X coordinate for the floating window.
+     */
+    val maxXCoordinate
+        get() = display.metrics.widthPixels - decorView.measuredWidth
+
+    /**
+     * The maximum Y coordinate for the floating window.
+     */
+    val maxYCoordinate
+        get() = display.metrics.heightPixels - decorView.measuredHeight
 
     /**
      * Sets the Jetpack Compose content for the floating window.

--- a/library/src/main/java/com/github/only52607/compose/window/DisplayHelper.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/DisplayHelper.kt
@@ -1,0 +1,38 @@
+package com.github.only52607.compose.window
+
+
+import android.content.Context
+import android.os.Build
+import android.util.DisplayMetrics
+import android.view.WindowManager
+
+/**
+ *
+ * This class provides a way to retrieve the display metrics of the current window.
+ *
+ */
+class DisplayHelper(
+    private val context: Context,
+    private val windowManager: WindowManager,
+) {
+
+    val metrics: DisplayMetrics
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val bounds = windowManager.currentWindowMetrics.bounds
+            val contextMetrics = context.resources.displayMetrics
+
+            val defaultMetrics = DisplayMetrics().apply {
+                widthPixels = bounds.width()
+                heightPixels = bounds.height()
+                density = contextMetrics.density
+                densityDpi = contextMetrics.densityDpi
+            }
+
+            defaultMetrics
+        } else {
+            DisplayMetrics().also {
+                @Suppress("DEPRECATION")
+                windowManager.defaultDisplay.getRealMetrics(it)
+            }
+        }
+}

--- a/library/src/main/java/com/github/only52607/compose/window/Dragger.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/Dragger.kt
@@ -1,12 +1,12 @@
 package com.github.only52607.compose.window
 
-import android.graphics.Rect
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
+import kotlin.math.roundToInt
 
 @Composable
 fun Modifier.dragFloatingWindow(
@@ -17,7 +17,8 @@ fun Modifier.dragFloatingWindow(
 ): Modifier {
     val floatingWindow = LocalFloatingWindow.current
     val windowParams = remember { floatingWindow.windowParams }
-    val dragModifier = Modifier
+
+    return this
         .pointerInput(Unit) {
             detectDragGestures(
                 onDragStart = onDragStart,
@@ -25,11 +26,12 @@ fun Modifier.dragFloatingWindow(
                 onDragCancel = onDragCancel,
             ) { change, dragAmount ->
                 change.consume()
-                val w = floatingWindow.decorView.width
-                val h = floatingWindow.decorView.height
-                val f = Rect().also { floatingWindow.decorView.getWindowVisibleDisplayFrame(it) }
-                val left = (windowParams.x + dragAmount.x.toInt()).coerceIn(0..(f.width() - w))
-                val top = (windowParams.y + dragAmount.y.toInt()).coerceIn(0..(f.height() - h))
+
+                val targetX = floatingWindow.windowParams.x + dragAmount.x.roundToInt()
+                val targetY = floatingWindow.windowParams.y + dragAmount.y.roundToInt()
+
+                val left = targetX.coerceIn(0, floatingWindow.maxXCoordinate)
+                val top = targetY.coerceIn(0, floatingWindow.maxYCoordinate)
 
                 windowParams.x = left
                 windowParams.y = top
@@ -39,6 +41,4 @@ fun Modifier.dragFloatingWindow(
                 floatingWindow.update()
             }
         }
-
-    return this then dragModifier
 }


### PR DESCRIPTION
Introduce a DisplayHelper class to retrieve display metrics and update dragFloatingWindow to utilize maximum coordinates for better boundary management during dragging.