### PR TITLE
fix: Compose Overlay problem

### DIFF
--- a/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -80,8 +80,6 @@ class ComposeFloatingWindow(
     AutoCloseable {
 
     companion object {
-        private const val TAG = "ComposeFloatingWindow"
-
         /**
          * Creates default [WindowManager.LayoutParams] suitable for a basic floating window.
          * Sets WRAP_CONTENT dimensions, translucency, top-start gravity, default animations,

--- a/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -233,18 +233,10 @@ class ComposeFloatingWindow(
             lifecycleCoroutineScope.launch {
                 try {
                     recomposer.runRecomposeAndApplyChanges()
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    Log.d(TAG, "Coroutine scope cancelled normally: ${e.message}")
                 } catch (e: Exception) {
-                    // Only log non-CancellationException errors as warnings,
-                    // since CancellationException is expected
-                    when (e) {
-                        is kotlinx.coroutines.CancellationException -> {
-                            Log.d(TAG, "Coroutine scope cancelled normally: ${e.message}")
-                        }
-
-                        else -> {
-                            Log.e(TAG, "Recomposer error", e)
-                        }
-                    }
+                    Log.e(TAG, "Recomposer error", e)
                 } finally {
                     Log.d(TAG, "Recomposer job finished.")
                 }
@@ -452,18 +444,10 @@ class ComposeFloatingWindow(
             lifecycleCoroutineScope.cancel(
                 kotlinx.coroutines.CancellationException("ComposeFloatingWindow destroyed")
             )
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            Log.d(TAG, "Coroutine scope cancelled normally: ${e.message}")
         } catch (e: Exception) {
-            // Only log non-CancellationException errors as warnings,
-            // since CancellationException is expected
-            when (e) {
-                is kotlinx.coroutines.CancellationException -> {
-                    Log.d(TAG, "Coroutine scope cancelled normally: ${e.message}")
-                }
-
-                else -> {
-                    Log.e(TAG, "Recomposer error", e)
-                }
-            }
+            Log.e(TAG, "Recomposer error", e)
         }
 
         // Move lifecycle to DESTROYED

--- a/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -377,6 +377,13 @@ class ComposeFloatingWindow(
     fun isAvailable(): Boolean = Settings.canDrawOverlays(context)
 
     init {
+        // Warn if non-application context is used to prevent memory leaks
+        if (context !is Application && context.applicationContext != context) {
+            Log.w(
+                TAG, "Consider using applicationContext " +
+                        "instead of activity context to prevent memory leaks"
+            )
+        }
         // Restore state early in the lifecycle
         savedStateRegistryController.performRestore(null)
         // Mark the lifecycle as CREATED

--- a/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -92,8 +92,9 @@ class ComposeFloatingWindow(
             format = PixelFormat.TRANSLUCENT
             gravity = Gravity.START or Gravity.TOP
             windowAnimations = android.R.style.Animation_Dialog
-            flags = (WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL // Allows touches to pass through
-                    or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE) // Prevents the window from taking focus (e.g., keyboard)
+            flags =
+                (WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL // Allows touches to pass through
+                        or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE) // Prevents the window from taking focus (e.g., keyboard)
 
             // Set window type correctly for overlays
             // Requires SYSTEM_ALERT_WINDOW permission
@@ -115,8 +116,10 @@ class ComposeFloatingWindow(
     private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
         Log.e(TAG, "Coroutine Exception: ${throwable.localizedMessage}", throwable)
     }
-    private val lifecycleCoroutineScope = CoroutineScope(SupervisorJob() +
-            AndroidUiDispatcher.CurrentThread + coroutineExceptionHandler)
+    private val lifecycleCoroutineScope = CoroutineScope(
+        SupervisorJob() +
+                AndroidUiDispatcher.CurrentThread + coroutineExceptionHandler
+    )
 
     override val defaultViewModelProviderFactory: ViewModelProvider.Factory by lazy {
         SavedStateViewModelFactory(
@@ -338,7 +341,7 @@ class ComposeFloatingWindow(
         Log.d(TAG, "Updating window layout.")
         try {
             windowManager.updateViewLayout(decorView, windowParams)
-        } catch (e: Exception){
+        } catch (e: Exception) {
             Log.e(TAG, "Error updating window layout: ${e.localizedMessage}", e)
         }
     }
@@ -432,7 +435,7 @@ class ComposeFloatingWindow(
         Log.d(TAG, "Destroying window...")
 
         // Hide the window if showing (ensures view is removed from WindowManager)
-        if(_isShowing.value){
+        if (_isShowing.value) {
             hide()
         }
 

--- a/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -116,9 +116,10 @@ class ComposeFloatingWindow(
     private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
         Log.e(TAG, "Coroutine Exception: ${throwable.localizedMessage}", throwable)
     }
+    private val coroutineContext = AndroidUiDispatcher.CurrentThread
     private val lifecycleCoroutineScope = CoroutineScope(
         SupervisorJob() +
-                AndroidUiDispatcher.CurrentThread + coroutineExceptionHandler
+                coroutineContext + coroutineExceptionHandler
     )
 
     override val defaultViewModelProviderFactory: ViewModelProvider.Factory by lazy {
@@ -224,7 +225,7 @@ class ComposeFloatingWindow(
             setViewTreeSavedStateRegistryOwner(this@ComposeFloatingWindow)
 
             // Create a Recomposer tied to the window's lifecycle scope
-            val recomposer = Recomposer(lifecycleCoroutineScope.coroutineContext)
+            val recomposer = Recomposer(coroutineContext)
             compositionContext = recomposer
             parentComposition = recomposer // Store for later disposal
 

--- a/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -427,13 +427,13 @@ class ComposeFloatingWindow(
         }
         Log.d(TAG, "Destroying window...")
 
+        // Mark as destroyed immediately to prevent race conditions
+        _isDestroyed.update { true }
+
         // Hide the window if showing (ensures view is removed from WindowManager)
         if (_isShowing.value) {
             hide()
         }
-
-        // Mark as destroyed immediately to prevent race conditions
-        _isDestroyed.update { true }
 
         // Dispose the composition
         disposeCompositionIfNeeded()

--- a/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -432,7 +432,11 @@ class ComposeFloatingWindow(
 
         // Hide the window if showing (ensures view is removed from WindowManager)
         if (_isShowing.value) {
-            hide()
+            try {
+                hide()
+            } catch (e: Exception) {
+                Log.e(TAG, "Error hiding window during destruction: ${e.localizedMessage}", e)
+            }
         }
 
         // Dispose the composition

--- a/library/src/main/java/com/github/only52607/compose/window/Dragger.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/Dragger.kt
@@ -1,5 +1,6 @@
 package com.github.only52607.compose.window
 
+import android.util.Log
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -33,12 +34,19 @@ fun Modifier.dragFloatingWindow(
                 val left = targetX.coerceIn(0, floatingWindow.maxXCoordinate)
                 val top = targetY.coerceIn(0, floatingWindow.maxYCoordinate)
 
-                windowParams.x = left
-                windowParams.y = top
+                synchronized(windowParams) {
+                    windowParams.x = left
+                    windowParams.y = top
+                }
 
                 onDrag?.invoke(left, top)
 
-                floatingWindow.update()
+                try {
+                    floatingWindow.update()
+                } catch (e: Exception) {
+                    // Log but don't crash on update failures during drag
+                    Log.w(TAG, "Failed to update window position: ${e.message}")
+                }
             }
         }
 }

--- a/library/src/main/java/com/github/only52607/compose/window/LocalFloatingWindow.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/LocalFloatingWindow.kt
@@ -4,9 +4,5 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 
 val LocalFloatingWindow: ProvidableCompositionLocal<ComposeFloatingWindow> = compositionLocalOf {
-    noLocalProvidedFor("LocalFloatingWindow")
-}
-
-private fun noLocalProvidedFor(name: String): Nothing {
-    error("CompositionLocal $name not present")
+    error("CompositionLocal \"LocalFloatingWindow\" not present")
 }

--- a/library/src/main/java/com/github/only52607/compose/window/Tag.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/Tag.kt
@@ -1,0 +1,3 @@
+package com.github.only52607.compose.window
+
+internal const val TAG = "ComposeFloatingWindow"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Additional context
<!-- Add any other context about the pull request here. -->

This pull request includes several updates to the `ComposeFloatingWindow` class and related files, focusing on improving error handling, lifecycle management, and code maintainability. Key changes include refactoring coroutine handling, enhancing error logging, and introducing thread safety for window updates.

### Improvements to error handling:

* Refactored error logging in coroutine exception handling to distinguish between `CancellationException` and other exceptions, ensuring appropriate log levels are used (`ComposeFloatingWindow.kt`, [[1]](diffhunk://#diff-574b82104274d840d4da7583af1c2c2916b23585696fbdbce55338ab684d7b36L226-L245) [[2]](diffhunk://#diff-574b82104274d840d4da7583af1c2c2916b23585696fbdbce55338ab684d7b36L453-L465).
* Added error logging for failures during window hiding and drag position updates to prevent crashes while providing diagnostic information (`ComposeFloatingWindow.kt`, [[1]](diffhunk://#diff-574b82104274d840d4da7583af1c2c2916b23585696fbdbce55338ab684d7b36R437-L442); `Dragger.kt`, [[2]](diffhunk://#diff-0eb12aace0846ecd0e58d27d172b6e5d5696955fb32991aac30bb997522f4552R37-R49).

### Lifecycle and coroutine management:

* Extracted `coroutineContext` from `lifecycleCoroutineScope` for clarity and reused it in the `Recomposer` initialization (`ComposeFloatingWindow.kt`, [[1]](diffhunk://#diff-574b82104274d840d4da7583af1c2c2916b23585696fbdbce55338ab684d7b36L120-R123) [[2]](diffhunk://#diff-574b82104274d840d4da7583af1c2c2916b23585696fbdbce55338ab684d7b36L226-L245).
* Improved lifecycle handling by marking the window as destroyed earlier during the destruction process to avoid race conditions (`ComposeFloatingWindow.kt`, [library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.ktR437-L442](diffhunk://#diff-574b82104274d840d4da7583af1c2c2916b23585696fbdbce55338ab684d7b36R437-L442)).

### Code maintainability and safety:

* Warned against using non-application contexts to prevent potential memory leaks (`ComposeFloatingWindow.kt`, [library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.ktR380-R386](diffhunk://#diff-574b82104274d840d4da7583af1c2c2916b23585696fbdbce55338ab684d7b36R380-R386)).
* Centralized the `TAG` constant into a separate file for consistency across the codebase (`Tag.kt`, [library/src/main/java/com/github/only52607/compose/window/Tag.ktR1-R3](diffhunk://#diff-89c821fa173b43f090f821e11e558c645a059f6505acd3442489d1a8807c1f27R1-R3)).
* Simplified error handling for `LocalFloatingWindow` by removing an unused helper function (`LocalFloatingWindow.kt`, [library/src/main/java/com/github/only52607/compose/window/LocalFloatingWindow.ktL7-R7](diffhunk://#diff-6f5bb6458a925338d26918322d218ddeaa1bf3d0e3d18de6fd9e8f541ad03180L7-R7)).

### Thread safety:

* Introduced synchronization when updating window parameters during drag operations to ensure thread safety (`Dragger.kt`, [library/src/main/java/com/github/only52607/compose/window/Dragger.ktR37-R49](diffhunk://#diff-0eb12aace0846ecd0e58d27d172b6e5d5696955fb32991aac30bb997522f4552R37-R49)).